### PR TITLE
Add functionality to mark/unmark matches as underway

### DIFF
--- a/core/src/main/java/at/stefangeyer/challonge/Challonge.java
+++ b/core/src/main/java/at/stefangeyer/challonge/Challonge.java
@@ -365,19 +365,19 @@ public class Challonge implements ChallongeService {
     public final Match markMatchAsUnderway(Match match) throws DataAccessException {
     	return this.service.markMatchAsUnderway(match);
     }
-    
+
     public final void markMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
     	this.service.markMatchAsUnderway(match, onSuccess, onFailure);
     }
-    
+
     public final Match unmarkMatchAsUnderway(Match match) throws DataAccessException {
     	return this.service.unmarkMatchAsUnderway(match);
     }
-    
+
     public final void unmarkMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
     	this.service.unmarkMatchAsUnderway(match, onSuccess, onFailure);
     }
-    
+
     public final Match reopenMatch(Match match) throws DataAccessException {
         return this.service.reopenMatch(match);
     }

--- a/core/src/main/java/at/stefangeyer/challonge/Challonge.java
+++ b/core/src/main/java/at/stefangeyer/challonge/Challonge.java
@@ -25,7 +25,7 @@ public class Challonge implements ChallongeService {
     public Challonge(Credentials credentials, Serializer serializer, RestClient restClient) {
         // Initialize factory
         restClient.initialize(credentials, serializer);
-        
+
         this.service = new SimpleChallongeService(restClient);
     }
 
@@ -363,19 +363,19 @@ public class Challonge implements ChallongeService {
     }
 
     public final Match markMatchAsUnderway(Match match) throws DataAccessException {
-    	return this.service.markMatchAsUnderway(match);
+        return this.service.markMatchAsUnderway(match);
     }
 
     public final void markMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
-    	this.service.markMatchAsUnderway(match, onSuccess, onFailure);
+        this.service.markMatchAsUnderway(match, onSuccess, onFailure);
     }
 
     public final Match unmarkMatchAsUnderway(Match match) throws DataAccessException {
-    	return this.service.unmarkMatchAsUnderway(match);
+        return this.service.unmarkMatchAsUnderway(match);
     }
 
     public final void unmarkMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
-    	this.service.unmarkMatchAsUnderway(match, onSuccess, onFailure);
+        this.service.unmarkMatchAsUnderway(match, onSuccess, onFailure);
     }
 
     public final Match reopenMatch(Match match) throws DataAccessException {

--- a/core/src/main/java/at/stefangeyer/challonge/Challonge.java
+++ b/core/src/main/java/at/stefangeyer/challonge/Challonge.java
@@ -362,6 +362,22 @@ public class Challonge implements ChallongeService {
         this.service.updateMatch(match, data, onSuccess, onFailure);
     }
 
+    public final Match markMatchAsUnderway(Match match) throws DataAccessException {
+    	return this.service.markMatchAsUnderway(match);
+    }
+    
+    public final void markMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
+    	this.service.markMatchAsUnderway(match, onSuccess, onFailure);
+    }
+    
+    public final Match unmarkMatchAsUnderway(Match match) throws DataAccessException {
+    	return this.service.unmarkMatchAsUnderway(match);
+    }
+    
+    public final void unmarkMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
+    	this.service.unmarkMatchAsUnderway(match, onSuccess, onFailure);
+    }
+    
     public final Match reopenMatch(Match match) throws DataAccessException {
         return this.service.reopenMatch(match);
     }

--- a/core/src/main/java/at/stefangeyer/challonge/rest/RestClient.java
+++ b/core/src/main/java/at/stefangeyer/challonge/rest/RestClient.java
@@ -678,6 +678,48 @@ public interface RestClient {
                      Callback<DataAccessException> onFailure);
 
     /**
+     * Marks a match as underway
+     * 
+     * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
+     * @param matchId    The match's unique ID
+     * @return The updated match
+     * @throws DataAccessException Exchange with the rest api failed
+     */
+    MatchWrapper markMatchAsUnderway(String tournament, long matchId) throws DataAccessException;
+
+    /**
+     * Marks a match as underway
+     * 
+     * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
+     * @param matchId    The match's unique ID
+     * @param onSuccess  Called with result if call was successful
+     * @param onFailure  Called with exception if call was not successful
+     */
+    void markMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
+    		                 Callback<DataAccessException> onFailure);
+
+    /**
+     * Marks a match as not underway
+     * 
+     * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
+     * @param matchId    The match's unique ID
+     * @return The updated match
+     * @throws DataAccessException Exchange with the rest api failed
+     */
+    MatchWrapper unmarkMatchAsUnderway(String tournament, long matchId) throws DataAccessException;
+
+    /**
+     * Marks a match as underway
+     * 
+     * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
+     * @param matchId    The match's unique ID
+     * @param onSuccess  Called with result if call was successful
+     * @param onFailure  Called with exception if call was not successful
+     */
+    void unmarkMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
+    		                   Callback<DataAccessException> onFailure);
+
+    /**
      * Reopens a match that was marked completed, automatically resetting matches that follow it
      *
      * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim).

--- a/core/src/main/java/at/stefangeyer/challonge/rest/RestClient.java
+++ b/core/src/main/java/at/stefangeyer/challonge/rest/RestClient.java
@@ -696,7 +696,7 @@ public interface RestClient {
      * @param onFailure  Called with exception if call was not successful
      */
     void markMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
-    		                 Callback<DataAccessException> onFailure);
+                             Callback<DataAccessException> onFailure);
 
     /**
      * Marks a match as not underway
@@ -717,7 +717,7 @@ public interface RestClient {
      * @param onFailure  Called with exception if call was not successful
      */
     void unmarkMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
-    		                   Callback<DataAccessException> onFailure);
+                               Callback<DataAccessException> onFailure);
 
     /**
      * Reopens a match that was marked completed, automatically resetting matches that follow it

--- a/core/src/main/java/at/stefangeyer/challonge/rest/RestClient.java
+++ b/core/src/main/java/at/stefangeyer/challonge/rest/RestClient.java
@@ -699,7 +699,7 @@ public interface RestClient {
                              Callback<DataAccessException> onFailure);
 
     /**
-     * Marks a match as not underway
+     * Unmarks a match as underway
      *
      * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
      * @param matchId    The match's unique ID

--- a/core/src/main/java/at/stefangeyer/challonge/rest/RestClient.java
+++ b/core/src/main/java/at/stefangeyer/challonge/rest/RestClient.java
@@ -679,7 +679,7 @@ public interface RestClient {
 
     /**
      * Marks a match as underway
-     * 
+     *
      * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
      * @param matchId    The match's unique ID
      * @return The updated match
@@ -689,7 +689,7 @@ public interface RestClient {
 
     /**
      * Marks a match as underway
-     * 
+     *
      * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
      * @param matchId    The match's unique ID
      * @param onSuccess  Called with result if call was successful
@@ -700,7 +700,7 @@ public interface RestClient {
 
     /**
      * Marks a match as not underway
-     * 
+     *
      * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
      * @param matchId    The match's unique ID
      * @return The updated match
@@ -710,7 +710,7 @@ public interface RestClient {
 
     /**
      * Marks a match as underway
-     * 
+     *
      * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
      * @param matchId    The match's unique ID
      * @param onSuccess  Called with result if call was successful

--- a/core/src/main/java/at/stefangeyer/challonge/service/ChallongeService.java
+++ b/core/src/main/java/at/stefangeyer/challonge/service/ChallongeService.java
@@ -586,18 +586,18 @@ public interface ChallongeService {
     void markMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure);
 
     /**
-     * Marks a match as not underway
+     * Unmarks a match as underway
      *
-     * @param match The match to mark as not underway. Must contain the tournament- and match id
+     * @param match The match to unmark as underway. Must contain the tournament- and match id
      * @return The updated match
      * @throws DataAccessException Exchange with the rest api failed
      */
     Match unmarkMatchAsUnderway(Match match) throws DataAccessException;
 
     /**
-     * Marks a match as not underway
+     * Unmarks a match as underway
      *
-     * @param match     The match to mark as not underway. Must contain the tournament- and match id
+     * @param match     The match to unmark as underway. Must contain the tournament- and match id
      * @param onSuccess Called with result if call was successful
      * @param onFailure Called with exception if call was not successful
      */

--- a/core/src/main/java/at/stefangeyer/challonge/service/ChallongeService.java
+++ b/core/src/main/java/at/stefangeyer/challonge/service/ChallongeService.java
@@ -568,6 +568,42 @@ public interface ChallongeService {
     void updateMatch(Match match, MatchQuery data, Callback<Match> onSuccess, Callback<DataAccessException> onFailure);
 
     /**
+     * Marks a match as underway
+     * 
+     * @param match The match to mark as underway. Must contain the tournament- and match id
+     * @return The updated match
+     * @throws DataAccessException Exchange with the rest api failed
+     */
+    Match markMatchAsUnderway(Match match) throws DataAccessException;
+    
+    /**
+     * Marks a match as underway
+     * 
+     * @param match     The match to mark as underway. Must contain the tournament- and match id
+     * @param onSuccess Called with result if call was successful
+     * @param onFailure Called with exception if call was not successful
+     */
+    void markMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure);
+    
+    /**
+     * Marks a match as not underway
+     * 
+     * @param match The match to mark as not underway. Must contain the tournament- and match id
+     * @return The updated match
+     * @throws DataAccessException Exchange with the rest api failed
+     */
+    Match unmarkMatchAsUnderway(Match match) throws DataAccessException;
+    
+    /**
+     * Marks a match as not underway
+     * 
+     * @param match     The match to mark as not underway. Must contain the tournament- and match id
+     * @param onSuccess Called with result if call was successful
+     * @param onFailure Called with exception if call was not successful
+     */
+    void unmarkMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure);
+    
+    /**
      * Reopens a match that was marked completed, automatically resetting matches that follow it.
      *
      * @param match The match to reopen. Must contain the tournament- and match id

--- a/core/src/main/java/at/stefangeyer/challonge/service/ChallongeService.java
+++ b/core/src/main/java/at/stefangeyer/challonge/service/ChallongeService.java
@@ -569,7 +569,7 @@ public interface ChallongeService {
 
     /**
      * Marks a match as underway
-     * 
+     *
      * @param match The match to mark as underway. Must contain the tournament- and match id
      * @return The updated match
      * @throws DataAccessException Exchange with the rest api failed
@@ -578,7 +578,7 @@ public interface ChallongeService {
 
     /**
      * Marks a match as underway
-     * 
+     *
      * @param match     The match to mark as underway. Must contain the tournament- and match id
      * @param onSuccess Called with result if call was successful
      * @param onFailure Called with exception if call was not successful
@@ -587,7 +587,7 @@ public interface ChallongeService {
 
     /**
      * Marks a match as not underway
-     * 
+     *
      * @param match The match to mark as not underway. Must contain the tournament- and match id
      * @return The updated match
      * @throws DataAccessException Exchange with the rest api failed
@@ -596,7 +596,7 @@ public interface ChallongeService {
 
     /**
      * Marks a match as not underway
-     * 
+     *
      * @param match     The match to mark as not underway. Must contain the tournament- and match id
      * @param onSuccess Called with result if call was successful
      * @param onFailure Called with exception if call was not successful

--- a/core/src/main/java/at/stefangeyer/challonge/service/ChallongeService.java
+++ b/core/src/main/java/at/stefangeyer/challonge/service/ChallongeService.java
@@ -575,7 +575,7 @@ public interface ChallongeService {
      * @throws DataAccessException Exchange with the rest api failed
      */
     Match markMatchAsUnderway(Match match) throws DataAccessException;
-    
+
     /**
      * Marks a match as underway
      * 
@@ -584,7 +584,7 @@ public interface ChallongeService {
      * @param onFailure Called with exception if call was not successful
      */
     void markMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure);
-    
+
     /**
      * Marks a match as not underway
      * 
@@ -593,7 +593,7 @@ public interface ChallongeService {
      * @throws DataAccessException Exchange with the rest api failed
      */
     Match unmarkMatchAsUnderway(Match match) throws DataAccessException;
-    
+
     /**
      * Marks a match as not underway
      * 
@@ -602,7 +602,7 @@ public interface ChallongeService {
      * @param onFailure Called with exception if call was not successful
      */
     void unmarkMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure);
-    
+
     /**
      * Reopens a match that was marked completed, automatically resetting matches that follow it.
      *

--- a/core/src/main/java/at/stefangeyer/challonge/service/implementation/SimpleChallongeService.java
+++ b/core/src/main/java/at/stefangeyer/challonge/service/implementation/SimpleChallongeService.java
@@ -389,24 +389,24 @@ public class SimpleChallongeService implements ChallongeService {
 
     @Override
     public Match markMatchAsUnderway(Match match) throws DataAccessException {
-    	return this.restClient.markMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId()).getMatch();
+        return this.restClient.markMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId()).getMatch();
     }
 
     @Override
     public void markMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
-    	this.restClient.markMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId(),
-    			mw -> onSuccess.accept(mw.getMatch()), onFailure);
+        this.restClient.markMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId(),
+                mw -> onSuccess.accept(mw.getMatch()), onFailure);
     }
 
     @Override
     public Match unmarkMatchAsUnderway(Match match) throws DataAccessException {
-    	return this.restClient.unmarkMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId()).getMatch();
+        return this.restClient.unmarkMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId()).getMatch();
     }
 
     @Override
     public void unmarkMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
-    	this.restClient.unmarkMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId(),
-    			mw -> onSuccess.accept(mw.getMatch()), onFailure);
+        this.restClient.unmarkMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId(),
+                mw -> onSuccess.accept(mw.getMatch()), onFailure);
     }
 
     @Override

--- a/core/src/main/java/at/stefangeyer/challonge/service/implementation/SimpleChallongeService.java
+++ b/core/src/main/java/at/stefangeyer/challonge/service/implementation/SimpleChallongeService.java
@@ -391,24 +391,24 @@ public class SimpleChallongeService implements ChallongeService {
     public Match markMatchAsUnderway(Match match) throws DataAccessException {
     	return this.restClient.markMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId()).getMatch();
     }
-    
+
     @Override
     public void markMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
     	this.restClient.markMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId(),
     			mw -> onSuccess.accept(mw.getMatch()), onFailure);
     }
-    
+
     @Override
     public Match unmarkMatchAsUnderway(Match match) throws DataAccessException {
     	return this.restClient.unmarkMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId()).getMatch();
     }
-    
+
     @Override
     public void unmarkMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
     	this.restClient.unmarkMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId(),
     			mw -> onSuccess.accept(mw.getMatch()), onFailure);
     }
-    
+
     @Override
     public Match reopenMatch(Match match) throws DataAccessException {
         return this.restClient.reopenMatch(String.valueOf(match.getTournamentId()), match.getId()).getMatch();

--- a/core/src/main/java/at/stefangeyer/challonge/service/implementation/SimpleChallongeService.java
+++ b/core/src/main/java/at/stefangeyer/challonge/service/implementation/SimpleChallongeService.java
@@ -388,6 +388,28 @@ public class SimpleChallongeService implements ChallongeService {
     }
 
     @Override
+    public Match markMatchAsUnderway(Match match) throws DataAccessException {
+    	return this.restClient.markMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId()).getMatch();
+    }
+    
+    @Override
+    public void markMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
+    	this.restClient.markMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId(),
+    			mw -> onSuccess.accept(mw.getMatch()), onFailure);
+    }
+    
+    @Override
+    public Match unmarkMatchAsUnderway(Match match) throws DataAccessException {
+    	return this.restClient.unmarkMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId()).getMatch();
+    }
+    
+    @Override
+    public void unmarkMatchAsUnderway(Match match, Callback<Match> onSuccess, Callback<DataAccessException> onFailure) {
+    	this.restClient.unmarkMatchAsUnderway(String.valueOf(match.getTournamentId()), match.getId(),
+    			mw -> onSuccess.accept(mw.getMatch()), onFailure);
+    }
+    
+    @Override
     public Match reopenMatch(Match match) throws DataAccessException {
         return this.restClient.reopenMatch(String.valueOf(match.getTournamentId()), match.getId()).getMatch();
     }

--- a/core/src/test/java/at/stefangeyer/challonge/unit/MatchTest.java
+++ b/core/src/test/java/at/stefangeyer/challonge/unit/MatchTest.java
@@ -151,7 +151,7 @@ public class MatchTest {
 
             return null;
         }).when(mrc).markMatchAsUnderway(any(), anyLong(), any(), any());
-        
+
         when(mrc.unmarkMatchAsUnderway(any(), anyLong())).thenAnswer(i -> {
             Tournament t = getTournament(i.getArgument(0));
             Match m = getMatch(t, i.getArgument(1));
@@ -172,7 +172,7 @@ public class MatchTest {
 
             return null;
         }).when(mrc).unmarkMatchAsUnderway(any(), anyLong(), any(), any());
-        
+
         when(mrc.reopenMatch(any(), anyLong())).thenAnswer(i -> {
             Tournament t = getTournament(i.getArgument(0));
             Match m = getMatch(t, i.getArgument(1));
@@ -307,22 +307,22 @@ public class MatchTest {
     @Test
     public void testMarkMatchAsUnderwayAsync() throws InterruptedException {
     	CountDownLatch latch = new CountDownLatch(0);
-    	
+
     	Tournament tournament = getTournament("tourney123");
     	Match match = tournament.getMatches().get(0);
-    	
+
     	this.challonge.markMatchAsUnderway(match, m -> {
     		this.holder[0] = m;
     		latch.countDown();
     	}, e -> {
     	});
-    	
+
     	latch.await(2000, TimeUnit.MILLISECONDS);
-    	
+
     	Match local = (Match) this.holder[0];
     	assertNotNull(local.getUnderwayAt());
     }
-    
+
     @Test
     public void testUnmarkMatchAsUnderway() throws DataAccessException {
     	Tournament tournament = getTournament("tourney123");
@@ -330,7 +330,7 @@ public class MatchTest {
     	Match local = this.challonge.unmarkMatchAsUnderway(match);
     	assertNull(local.getUnderwayAt());
     }
-    
+
     @Test
     public void testUnmarkMatchAsUnderwayAsync() throws InterruptedException {
     	CountDownLatch latch = new CountDownLatch(0);

--- a/core/src/test/java/at/stefangeyer/challonge/unit/MatchTest.java
+++ b/core/src/test/java/at/stefangeyer/challonge/unit/MatchTest.java
@@ -298,58 +298,58 @@ public class MatchTest {
 
     @Test
     public void testMarkMatchAsUnderway() throws DataAccessException {
-    	Tournament tournament = getTournament("tourney123");
-    	Match match = tournament.getMatches().get(0);
-    	Match local = this.challonge.markMatchAsUnderway(match);
-    	assertNotNull(local.getUnderwayAt());
+        Tournament tournament = getTournament("tourney123");
+        Match match = tournament.getMatches().get(0);
+        Match local = this.challonge.markMatchAsUnderway(match);
+        assertNotNull(local.getUnderwayAt());
     }
 
     @Test
     public void testMarkMatchAsUnderwayAsync() throws InterruptedException {
-    	CountDownLatch latch = new CountDownLatch(0);
+        CountDownLatch latch = new CountDownLatch(0);
 
-    	Tournament tournament = getTournament("tourney123");
-    	Match match = tournament.getMatches().get(0);
+        Tournament tournament = getTournament("tourney123");
+        Match match = tournament.getMatches().get(0);
 
-    	this.challonge.markMatchAsUnderway(match, m -> {
-    		this.holder[0] = m;
-    		latch.countDown();
-    	}, e -> {
-    	});
+        this.challonge.markMatchAsUnderway(match, m -> {
+            this.holder[0] = m;
+            latch.countDown();
+        }, e -> {
+        });
 
-    	latch.await(2000, TimeUnit.MILLISECONDS);
+        latch.await(2000, TimeUnit.MILLISECONDS);
 
-    	Match local = (Match) this.holder[0];
-    	assertNotNull(local.getUnderwayAt());
+        Match local = (Match) this.holder[0];
+        assertNotNull(local.getUnderwayAt());
     }
 
     @Test
     public void testUnmarkMatchAsUnderway() throws DataAccessException {
-    	Tournament tournament = getTournament("tourney123");
-    	Match match = tournament.getMatches().get(0);
-    	Match local = this.challonge.unmarkMatchAsUnderway(match);
-    	assertNull(local.getUnderwayAt());
+        Tournament tournament = getTournament("tourney123");
+        Match match = tournament.getMatches().get(0);
+        Match local = this.challonge.unmarkMatchAsUnderway(match);
+        assertNull(local.getUnderwayAt());
     }
 
     @Test
     public void testUnmarkMatchAsUnderwayAsync() throws InterruptedException {
-    	CountDownLatch latch = new CountDownLatch(0);
-    	
-    	Tournament tournament = getTournament("tourney123");
-    	Match match = tournament.getMatches().get(0);
-    	
-    	this.challonge.unmarkMatchAsUnderway(match, m -> {
-    		this.holder[0] = m;
-    		latch.countDown();
-    	}, e -> {
-    	});
-    	
-    	latch.await(2000, TimeUnit.MILLISECONDS);
-    	
-    	Match local = (Match) this.holder[0];
-    	assertNull(local.getUnderwayAt());
+        CountDownLatch latch = new CountDownLatch(0);
+
+        Tournament tournament = getTournament("tourney123");
+        Match match = tournament.getMatches().get(0);
+
+        this.challonge.unmarkMatchAsUnderway(match, m -> {
+            this.holder[0] = m;
+            latch.countDown();
+        }, e -> {
+        });
+
+        latch.await(2000, TimeUnit.MILLISECONDS);
+
+        Match local = (Match) this.holder[0];
+        assertNull(local.getUnderwayAt());
     }
-    
+
     @Test
     public void testReopenMatch() throws DataAccessException {
         Tournament tournament = getTournament("tourney123");

--- a/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/ChallongeRetrofit.java
+++ b/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/ChallongeRetrofit.java
@@ -350,6 +350,26 @@ public interface ChallongeRetrofit {
     Call<MatchWrapper> updateMatch(@Path("tournament") String tournament,
                                    @Path("match_id") long matchId,
                                    @Body MatchQueryWrapper match);
+    /**
+     * Marks a match as underway
+     * 
+     * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
+     * @param matchId    The match's unique ID
+     * @return Call
+     */
+    @POST("tournaments/{tournament}/matches/{match_id}/mark_as_underway.json")
+    Call<MatchWrapper> markMatchAsUnderway(@Path("tournament") String tournament,
+                                           @Path("match_id") long matchId);
+    /**
+     * Marks a match as not underway
+     * 
+     * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
+     * @param matchId    The match's unique ID
+     * @return Call
+     */
+    @POST("tournaments/{tournament}/matches/{match_id}/unmark_as_underway.json")
+    Call<MatchWrapper> unmarkMatchAsUnderway(@Path("tournament") String tournament,
+                                           @Path("match_id") long matchId);
 
     /**
      * Reopens a match that was marked completed, automatically resetting matches that follow it

--- a/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/ChallongeRetrofit.java
+++ b/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/ChallongeRetrofit.java
@@ -350,6 +350,7 @@ public interface ChallongeRetrofit {
     Call<MatchWrapper> updateMatch(@Path("tournament") String tournament,
                                    @Path("match_id") long matchId,
                                    @Body MatchQueryWrapper match);
+
     /**
      * Marks a match as underway
      * 
@@ -360,6 +361,7 @@ public interface ChallongeRetrofit {
     @POST("tournaments/{tournament}/matches/{match_id}/mark_as_underway.json")
     Call<MatchWrapper> markMatchAsUnderway(@Path("tournament") String tournament,
                                            @Path("match_id") long matchId);
+
     /**
      * Marks a match as not underway
      * 

--- a/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/ChallongeRetrofit.java
+++ b/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/ChallongeRetrofit.java
@@ -363,7 +363,7 @@ public interface ChallongeRetrofit {
                                            @Path("match_id") long matchId);
 
     /**
-     * Marks a match as not underway
+     * Unmarks a match as underway
      *
      * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
      * @param matchId    The match's unique ID

--- a/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/ChallongeRetrofit.java
+++ b/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/ChallongeRetrofit.java
@@ -353,7 +353,7 @@ public interface ChallongeRetrofit {
 
     /**
      * Marks a match as underway
-     * 
+     *
      * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
      * @param matchId    The match's unique ID
      * @return Call
@@ -364,14 +364,14 @@ public interface ChallongeRetrofit {
 
     /**
      * Marks a match as not underway
-     * 
+     *
      * @param tournament Tournament ID (e.g. 10230) or URL (e.g. 'single_elim' for challonge.com/single_elim). If assigned to a subdomain, URL format must be :subdomain-:tournament_url (e.g. 'test-mytourney' for test.challonge.com/mytourney)
      * @param matchId    The match's unique ID
      * @return Call
      */
     @POST("tournaments/{tournament}/matches/{match_id}/unmark_as_underway.json")
     Call<MatchWrapper> unmarkMatchAsUnderway(@Path("tournament") String tournament,
-                                           @Path("match_id") long matchId);
+                                             @Path("match_id") long matchId);
 
     /**
      * Reopens a match that was marked completed, automatically resetting matches that follow it

--- a/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/RetrofitRestClient.java
+++ b/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/RetrofitRestClient.java
@@ -721,7 +721,7 @@ public class RetrofitRestClient implements RestClient, Closeable {
         try {
             response = this.challongeRetrofit.unmarkMatchAsUnderway(tournament, matchId).execute();
         } catch (IOException e) {
-            throw new DataAccessException("Error while marking match as not underway", e);
+            throw new DataAccessException("Error while unmarking match as underway", e);
         }
 
         return parse(response);
@@ -733,7 +733,7 @@ public class RetrofitRestClient implements RestClient, Closeable {
         checkInitialized();
 
         this.challongeRetrofit.unmarkMatchAsUnderway(tournament, matchId)
-                .enqueue(callback(onSuccess, onFailure, "Error while marking match as not underway"));
+                .enqueue(callback(onSuccess, onFailure, "Error while unmarking match as underway"));
     }
 
     @Override

--- a/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/RetrofitRestClient.java
+++ b/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/RetrofitRestClient.java
@@ -690,22 +690,22 @@ public class RetrofitRestClient implements RestClient, Closeable {
 
     @Override
     public MatchWrapper markMatchAsUnderway(String tournament, long matchId) throws DataAccessException {
-    	checkInitialized();
+        checkInitialized();
 
-    	Response<MatchWrapper> response;
+        Response<MatchWrapper> response;
 
-    	try {
-    		response = this.challongeRetrofit.markMatchAsUnderway(tournament, matchId).execute();
-    	} catch(IOException e) {
-    		throw new DataAccessException("Error while marking match as underway", e);
-    	}
+        try {
+            response = this.challongeRetrofit.markMatchAsUnderway(tournament, matchId).execute();
+        } catch (IOException e) {
+            throw new DataAccessException("Error while marking match as underway", e);
+        }
 
-    	return parse(response);
+        return parse(response);
     }
 
     @Override
     public void markMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
-    		Callback<DataAccessException> onFailure) {
+                                    Callback<DataAccessException> onFailure) {
         checkInitialized();
 
         this.challongeRetrofit.markMatchAsUnderway(tournament, matchId)
@@ -716,21 +716,21 @@ public class RetrofitRestClient implements RestClient, Closeable {
     public MatchWrapper unmarkMatchAsUnderway(String tournament, long matchId) throws DataAccessException {
         checkInitialized();
 
-    	Response<MatchWrapper> response;
+        Response<MatchWrapper> response;
 
-    	try {
-    		response = this.challongeRetrofit.unmarkMatchAsUnderway(tournament, matchId).execute();
-    	} catch(IOException e) {
-    		throw new DataAccessException("Error while marking match as not underway", e);
-    	}
+        try {
+            response = this.challongeRetrofit.unmarkMatchAsUnderway(tournament, matchId).execute();
+        } catch (IOException e) {
+            throw new DataAccessException("Error while marking match as not underway", e);
+        }
 
-    	return parse(response);
+        return parse(response);
     }
 
     @Override
     public void unmarkMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
-    		Callback<DataAccessException> onFailure) {
-    	checkInitialized();
+                                      Callback<DataAccessException> onFailure) {
+        checkInitialized();
 
         this.challongeRetrofit.unmarkMatchAsUnderway(tournament, matchId)
                 .enqueue(callback(onSuccess, onFailure, "Error while marking match as not underway"));

--- a/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/RetrofitRestClient.java
+++ b/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/RetrofitRestClient.java
@@ -691,18 +691,18 @@ public class RetrofitRestClient implements RestClient, Closeable {
     @Override
     public MatchWrapper markMatchAsUnderway(String tournament, long matchId) throws DataAccessException {
     	checkInitialized();
-    	
+
     	Response<MatchWrapper> response;
-    	
+
     	try {
     		response = this.challongeRetrofit.markMatchAsUnderway(tournament, matchId).execute();
     	} catch(IOException e) {
     		throw new DataAccessException("Error while marking match as underway", e);
     	}
-    	
+
     	return parse(response);
     }
-    
+
     @Override
     public void markMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
     		Callback<DataAccessException> onFailure) {
@@ -711,22 +711,22 @@ public class RetrofitRestClient implements RestClient, Closeable {
         this.challongeRetrofit.markMatchAsUnderway(tournament, matchId)
                 .enqueue(callback(onSuccess, onFailure, "Error while marking match as underway"));
     }
-    
+
     @Override
     public MatchWrapper unmarkMatchAsUnderway(String tournament, long matchId) throws DataAccessException {
         checkInitialized();
-    	
+
     	Response<MatchWrapper> response;
-    	
+
     	try {
     		response = this.challongeRetrofit.unmarkMatchAsUnderway(tournament, matchId).execute();
     	} catch(IOException e) {
     		throw new DataAccessException("Error while marking match as not underway", e);
     	}
-    	
+
     	return parse(response);
     }
-    
+
     @Override
     public void unmarkMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
     		Callback<DataAccessException> onFailure) {

--- a/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/RetrofitRestClient.java
+++ b/rest/retrofit/src/main/java/at/stefangeyer/challonge/rest/retrofit/RetrofitRestClient.java
@@ -685,7 +685,55 @@ public class RetrofitRestClient implements RestClient, Closeable {
         checkInitialized();
 
         this.challongeRetrofit.updateMatch(tournament, matchId, match)
-                .enqueue(callback(onSuccess, onFailure, "Error while updating matches"));
+                .enqueue(callback(onSuccess, onFailure, "Error while updating match"));
+    }
+
+    @Override
+    public MatchWrapper markMatchAsUnderway(String tournament, long matchId) throws DataAccessException {
+    	checkInitialized();
+    	
+    	Response<MatchWrapper> response;
+    	
+    	try {
+    		response = this.challongeRetrofit.markMatchAsUnderway(tournament, matchId).execute();
+    	} catch(IOException e) {
+    		throw new DataAccessException("Error while marking match as underway", e);
+    	}
+    	
+    	return parse(response);
+    }
+    
+    @Override
+    public void markMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
+    		Callback<DataAccessException> onFailure) {
+        checkInitialized();
+
+        this.challongeRetrofit.markMatchAsUnderway(tournament, matchId)
+                .enqueue(callback(onSuccess, onFailure, "Error while marking match as underway"));
+    }
+    
+    @Override
+    public MatchWrapper unmarkMatchAsUnderway(String tournament, long matchId) throws DataAccessException {
+        checkInitialized();
+    	
+    	Response<MatchWrapper> response;
+    	
+    	try {
+    		response = this.challongeRetrofit.unmarkMatchAsUnderway(tournament, matchId).execute();
+    	} catch(IOException e) {
+    		throw new DataAccessException("Error while marking match as not underway", e);
+    	}
+    	
+    	return parse(response);
+    }
+    
+    @Override
+    public void unmarkMatchAsUnderway(String tournament, long matchId, Callback<MatchWrapper> onSuccess,
+    		Callback<DataAccessException> onFailure) {
+    	checkInitialized();
+
+        this.challongeRetrofit.unmarkMatchAsUnderway(tournament, matchId)
+                .enqueue(callback(onSuccess, onFailure, "Error while marking match as not underway"));
     }
 
     @Override


### PR DESCRIPTION
Recently there was an [update to the API](https://api.challonge.com/v1/documents/changelog) so that it now allows marking and unmarking matches as underway via the routes [tournaments/{tournament}/matches/{match_id}/mark_as_underway](https://api.challonge.com/v1/documents/matches/mark_as_underway) and [tournaments/{tournament}/matches/{match_id}/unmark_as_underway](https://api.challonge.com/v1/documents/matches/unmark_as_underway) respectively.
This PR adds that functionality to the project.